### PR TITLE
feat: send sensor data to server

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -1,3 +1,4 @@
 name=ja485_2
 #assetOtaDir=assets
 dependencies.ModbusMaster-Particle=1.0.3
+dependencies.HttpClient=0.0.5


### PR DESCRIPTION
## Summary
- add HttpClient dependency and configuration
- send sensor readings to https://shefa.green/api/sensor-data with required headers
- publish result events with status codes for manual and scheduled pushes

## Testing
- `particle compile photon` (fails: You're not logged in)


------
https://chatgpt.com/codex/tasks/task_e_68a86dabfe74832fabe7e4f4c156f771